### PR TITLE
force ref push to remote ximera server

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -12,11 +12,11 @@ func gitPushXimera(ref string) error {
 	args := []string{"push", "ximera"}
 
 	if len(ref) > 0 {
-		args = []string{"push", "ximera", ref}
+		args = []string{"push", "ximera", "+"+ref}
 	}
 
 	if ref == "master" {
-		args = []string{"push", "--set-upstream", "ximera", ref}
+		args = []string{"push", "--set-upstream", "ximera", "+"+ref}
 	}
 
 	yellow := color.New(color.FgYellow)


### PR DESCRIPTION
Here is the requested "overwrite the frost tag on the server".

It should come up less often with the frost improvements, but is a simple fix.